### PR TITLE
check_domain also check for domain length

### DIFF
--- a/update-zonefile.py
+++ b/update-zonefile.py
@@ -111,7 +111,7 @@ def download_list(url):
             return f.read()
 
 def check_domain(domain, origin):
-    if domain == '':
+    if domain == '' or len(domain)>250:
         return False
 
     try:


### PR DESCRIPTION
As per RFC1035, the DNS name maximum length is 255 bytes. Some lists returns very long domain name and BIND will not charge the zone because the length is greater than 255 characters.