### PR TITLE
Add requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Uses the following sources:
 
 ### Python packages
 
-* [requests](https://pypi.python.org/pypi/requests)
-* [dnspython](https://pypi.python.org/pypi/dnspython)
+See [requirements.txt](requirements.txt)
 
-These packages need to be installed to run the update script.
+To install
+```
+pip install -r requirements.txt
+```
+
 
 ### Configure BIND
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2019.9.11
+chardet==3.0.4
+dnspython==1.16.0
+idna==2.8
+pathlib==1.0.1
+requests==2.22.0
+urllib3==1.25.7


### PR DESCRIPTION
Apparently pathlib is a requirement now, so figured it was easier to make a requirements file
I used pip freeze to generate it, but if you wanted i could change it to just be

```
requests
pathlib
dnspython
```

to just grab the latest version