### PR TITLE
20200516 - se-linux support and example crontab

### DIFF
--- a/example_root_crontab
+++ b/example_root_crontab
@@ -1,0 +1,20 @@
+# This is an example crontab file, which assumes the user (e.g. root) 
+# has no crontab file yet, at all.  You may want to do:
+# 'crontab -l' to validate that assumption...
+# if valid, feel free to edit values below, and then run 
+#     'crontab example_crontab_file'
+# if invalid, you'll need to merge at least the last line into your
+# current crontab file
+#
+# use /bin/bash to run commands, no matter what /etc/passwd says
+SHELL=/bin/bash
+# mail any output to user `nick', no matter whose crontab this is
+# nick is an example username...replace with your prefered recipient
+MAILTO=nick
+CRON_TZ=EST5EDT
+PATH=/usr/share/Modules/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+# run five minutes after 2am, every day
+# assumes your rpz domain file is /etc/bin/db.rpz.example.com and 
+# your rpz domain is named rpz.example.com in your BIND config
+5 2 * * * (cd /path/to/bind-adblock/bind-adblock-master; python3 ./update-zonefile.py /etc/bind/db.rpz.example.com rpz.example.com) 2>&1
+

--- a/update-zonefile.py
+++ b/update-zonefile.py
@@ -278,6 +278,15 @@ if __name__ == '__main__':
     else:
         if check_zone(args.origin, tmpzonefile):
             save_zone(tmpzonefile, args.zonefile, args.origin, args.raw_zone)
+            cmd = ['/usr/sbin/getenforce']
+            r = subprocess.check_output(cmd).strip()
+            print('SELinux getenforce output / Current State is: ',r)
+            if r == b'Enforcing':
+                print('SELinux restorecon being run to reset MAC security context on zone file')
+                cmd = ['/sbin/restorecon', '-F', args.zonefile]
+                r = subprocess.call(cmd)
+                if r != 0:
+                    raise Exception('Cannot run selinux restorecon on the zonefile - return code {}'.format(r))
             reload_zone(args.origin)
         else:
             print('Zone file invalid, not loading')

--- a/update-zonefile.py
+++ b/update-zonefile.py
@@ -250,6 +250,7 @@ if __name__ == '__main__':
     parser = ArgumentParser(description='Update zone file from public DNS ad blocking lists')
     parser.add_argument('--no-bind', dest='no_bind', action='store_true', help='Don\'t try to check/reload bind zone')
     parser.add_argument('--raw', dest='raw_zone', action='store_true', help='Save the zone file in raw format. Requires named-compilezone')
+    parser.add_argument('--empty', dest='empty', action='store_true', help='Create header-only (empty) rpz zone file')
     parser.add_argument('zonefile', help='path to zone file')
     parser.add_argument('origin', help='zone origin')
     args = parser.parse_args()
@@ -262,7 +263,10 @@ if __name__ == '__main__':
     zone = load_zone(args.zonefile, args.origin, args.raw_zone)
     update_serial(zone)
 
-    domains = parse_lists(args.origin)
+    if args.empty:
+        domains = set()
+    else:
+        domains = parse_lists(args.origin)
 
     tmpzonefile = Path(config['cache'], 'tempzone')
     zone.to_file(str(tmpzonefile))


### PR DESCRIPTION
This is the code I sent you as a diff like maybe 9-12 months ago, and I just got around to submitting through proper git process.  Sorry for the delay.  The se-linux code is added to ensure that if running on an enforcing se-linux system, it will set proper file attributes on the over-written .rpz file at the end of your script.

Additionally, I included an example crontab file, in case people want to have your script run every day, and want to collect the output in local host email.