### PR TITLE
20200912 - updated README.md to reflect updated command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Create a zone file for your zone. Replace example.com with the domain you used b
 
 ## Usage
 
-    usage: update-zonefile.py [-h] [--no-bind] zonefile origin
+    usage: update-zonefile.py [-h] [--no-bind] [--raw] [--empty] zonefile origin
 
     Update zone file from public DNS ad blocking lists
 
@@ -76,6 +76,7 @@ Create a zone file for your zone. Replace example.com with the domain you used b
       -h, --help  show this help message and exit
       --no-bind   Don't try to check/reload bind zone
       --raw       Save the zone file in raw format. Requires named-compilezone
+      --empty     Create header-only (empty) rpz zone file
 
 Example: `update-zonefile.py /etc/bind/db.rpz.example.com rpz.example.com`
 


### PR DESCRIPTION
I noticed that with my recent "--empty" option introduction, the README.md was no longer current. I only changed the README.md to reflect same output as 'python3 ./update-zonefile -h'