### PR TITLE
add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:latest
+
+ENV SRC="."
+
+VOLUME /bind-adblock
+
+COPY ${SRC}/blocklist.txt ./
+COPY ${SRC}/config.yml ./
+COPY ${SRC}/update-zonefile.py ./
+COPY ${SRC}/requirements.txt ./
+
+RUN pip install -r requirements.txt
+
+CMD ["python3", "./update-zonefile.py", "--no-bind", "/bind-adblock/rpz-adblocker.zone", "rpz.adblocker"]


### PR DESCRIPTION
I created a Dockerfile for this python script to run in.

By itself, it provides an environment for local testing.

`docker build .`
`docker run <id>`


There is an example docker-compose integrating this with a bind9 container where the adblock zone is written to a shared volume which I published over at [nabbi/docker-bind9-pihole](https://github.com/nabbi/docker-bind9-pihole). Welcome to pull more of that in here if you desire, I didn't want to clutter.

Hope this helps.
